### PR TITLE
feat: Add more observation sets to German lab bundle

### DIFF
--- a/scripts/generate_fhir_example.py
+++ b/scripts/generate_fhir_example.py
@@ -11,7 +11,7 @@ def main():
     bundle_json_str = fhir_bundle.model_dump_json(indent=2)
     bundle_dict = fhir_bundle.model_dump()
     df_full = flatten_fhir_bundle(bundle_dict)
-    df_subset = filter_fhir_dataframe(df_full, "code_coding_0_code", "2085-9")
+    df_subset = filter_fhir_dataframe(df_full, column_name="code_coding_0_code", codes=["2085-9"])
 
     print("--- FHIR Bundle (JSON) ---")
     print(bundle_json_str)

--- a/src/fhir_research/examples.py
+++ b/src/fhir_research/examples.py
@@ -73,3 +73,295 @@ def fhir_bundle_marimo_max():
     )
 
     return fhir_bundle
+
+
+def fhir_bundle_german_lab_example():
+    """Generates a FHIR bundle for Hans Schmidt with German lab observations."""
+
+    # Define Patient Data
+    patient_details = {
+        "id": "patient-example-02",
+        "family_name": "Schmidt",
+        "given_name": "Hans",
+        "birth_date": "1978-05-15",
+        "gender": "male",
+    }
+
+    # Define Observations Data
+    # Set 1: All lab parameters present
+    lab_observations_set1 = [
+        {
+            "observation_id": "obs-schmidt-01",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2324-2",
+            "code_display": "Gamma glutamyl transferase",
+            "value_quantity_value": 45.0,
+            "value_quantity_unit": "U/L",
+            "value_quantity_unit_code": "U/L",
+        },
+        {
+            "observation_id": "obs-schmidt-02",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "1558-6",
+            "code_display": "Glucose^fasting",
+            "value_quantity_value": 90.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-03",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2093-3",
+            "code_display": "Cholesterol",
+            "value_quantity_value": 200.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-04",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2085-9",
+            "code_display": "Cholesterol in HDL",
+            "value_quantity_value": 50.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-05",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2089-1",
+            "code_display": "Cholesterol in LDL",
+            "value_quantity_value": 130.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-06",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "9830-1",
+            "code_display": "Cholesterol.total/Cholesterol in HDL",
+            "value_quantity_value": 4.0,
+            "value_quantity_unit": "ratio",
+            "value_quantity_unit_code": "{ratio}", # UCUM code for ratio
+        },
+        {
+            "observation_id": "obs-schmidt-07",
+            "effective_date_time": "2022-05-20T07:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2571-8",
+            "code_display": "Triglyceride",
+            "value_quantity_value": 150.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+    ]
+
+    # Set 2: Triglyceride missing, other values slightly different
+    lab_observations_set2 = [
+        {
+            "observation_id": "obs-schmidt-08",
+            "effective_date_time": "2023-08-10T08:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2324-2",
+            "code_display": "Gamma glutamyl transferase",
+            "value_quantity_value": 48.0,
+            "value_quantity_unit": "U/L",
+            "value_quantity_unit_code": "U/L",
+        },
+        {
+            "observation_id": "obs-schmidt-09",
+            "effective_date_time": "2023-08-10T08:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "1558-6",
+            "code_display": "Glucose^fasting",
+            "value_quantity_value": 95.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-10",
+            "effective_date_time": "2023-08-10T08:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2093-3",
+            "code_display": "Cholesterol",
+            "value_quantity_value": 210.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-11",
+            "effective_date_time": "2023-08-10T08:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2085-9",
+            "code_display": "Cholesterol in HDL",
+            "value_quantity_value": 52.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-12",
+            "effective_date_time": "2023-08-10T08:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2089-1",
+            "code_display": "Cholesterol in LDL",
+            "value_quantity_value": 135.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-13",
+            "effective_date_time": "2023-08-10T08:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "9830-1",
+            "code_display": "Cholesterol.total/Cholesterol in HDL",
+            "value_quantity_value": 4.04, # 210 / 52 = 4.038...
+            "value_quantity_unit": "ratio",
+            "value_quantity_unit_code": "{ratio}", # UCUM code for ratio
+        },
+        # Triglyceride (LOINC "2571-8") is intentionally omitted here
+    ]
+
+    # Set 3: LDL-Cholesterin missing, other values varied
+    lab_observations_set3 = [
+        {
+            "observation_id": "obs-schmidt-14",
+            "effective_date_time": "2024-01-15T09:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2324-2", # Gamma-GT
+            "code_display": "Gamma glutamyl transferase",
+            "value_quantity_value": 50.0,
+            "value_quantity_unit": "U/L",
+            "value_quantity_unit_code": "U/L",
+        },
+        {
+            "observation_id": "obs-schmidt-15",
+            "effective_date_time": "2024-01-15T09:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "1558-6", # Glukose
+            "code_display": "Glucose^fasting",
+            "value_quantity_value": 92.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-16",
+            "effective_date_time": "2024-01-15T09:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2093-3", # Cholesterin
+            "code_display": "Cholesterol",
+            "value_quantity_value": 190.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-17",
+            "effective_date_time": "2024-01-15T09:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2085-9", # HDL-Cholesterin
+            "code_display": "Cholesterol in HDL",
+            "value_quantity_value": 55.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        # LDL-Cholesterin (LOINC "2089-1") is intentionally omitted here
+        {
+            "observation_id": "obs-schmidt-18",
+            "effective_date_time": "2024-01-15T09:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "9830-1", # Cholesterin/HDL-Chol.-Ratio
+            "code_display": "Cholesterol.total/Cholesterol in HDL",
+            "value_quantity_value": 3.45, # 190 / 55 = 3.45
+            "value_quantity_unit": "ratio",
+            "value_quantity_unit_code": "{ratio}",
+        },
+        {
+            "observation_id": "obs-schmidt-19",
+            "effective_date_time": "2024-01-15T09:00:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2571-8", # Triglyceride
+            "code_display": "Triglyceride",
+            "value_quantity_value": 140.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+    ]
+
+    # Set 4: Gamma-GT missing, other values varied
+    lab_observations_set4 = [
+        # Gamma-GT (LOINC "2324-2") is intentionally omitted here
+        {
+            "observation_id": "obs-schmidt-20",
+            "effective_date_time": "2024-07-20T09:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "1558-6", # Glukose
+            "code_display": "Glucose^fasting",
+            "value_quantity_value": 88.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-21",
+            "effective_date_time": "2024-07-20T09:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2093-3", # Cholesterin
+            "code_display": "Cholesterol",
+            "value_quantity_value": 195.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-22",
+            "effective_date_time": "2024-07-20T09:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2085-9", # HDL-Cholesterin
+            "code_display": "Cholesterol in HDL",
+            "value_quantity_value": 53.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-23",
+            "effective_date_time": "2024-07-20T09:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2089-1", # LDL-Cholesterin
+            "code_display": "Cholesterol in LDL",
+            "value_quantity_value": 125.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+        {
+            "observation_id": "obs-schmidt-24",
+            "effective_date_time": "2024-07-20T09:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "9830-1", # Cholesterin/HDL-Chol.-Ratio
+            "code_display": "Cholesterol.total/Cholesterol in HDL",
+            "value_quantity_value": 3.68, # 195 / 53 = 3.679...
+            "value_quantity_unit": "ratio",
+            "value_quantity_unit_code": "{ratio}",
+        },
+        {
+            "observation_id": "obs-schmidt-25",
+            "effective_date_time": "2024-07-20T09:30:00Z",
+            "code_system": "http://loinc.org",
+            "code": "2571-8", # Triglyceride
+            "code_display": "Triglyceride",
+            "value_quantity_value": 145.0,
+            "value_quantity_unit": "mg/dL",
+            "value_quantity_unit_code": "mg/dL",
+        },
+    ]
+
+    all_lab_observations = lab_observations_set1 + lab_observations_set2 + lab_observations_set3 + lab_observations_set4
+
+    # Generate FHIR Bundle
+    fhir_bundle = create_patient_lab_bundle(
+        patient_details=patient_details, lab_observations_details=all_lab_observations
+    )
+
+    return fhir_bundle

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,103 @@
+import unittest
+from fhir.resources.bundle import Bundle
+from fhir.resources.patient import Patient
+from fhir.resources.observation import Observation
+
+from src.fhir_research.examples import fhir_bundle_german_lab_example
+
+class TestExamples(unittest.TestCase):
+
+    def test_fhir_bundle_german_lab_example_structure(self):
+        """Test the basic structure and patient details of the German lab example bundle."""
+        bundle = fhir_bundle_german_lab_example()
+
+        self.assertIsInstance(bundle, Bundle)
+        self.assertEqual(bundle.type, "collection")
+        self.assertIsNotNone(bundle.entry)
+        self.assertTrue(len(bundle.entry) > 0) # Should have patient + observations
+
+        patient_entries = [e for e in bundle.entry if e.resource and e.resource.get_resource_type() == "Patient"]
+        self.assertEqual(len(patient_entries), 1)
+
+        patient_resource = patient_entries[0].resource
+        self.assertIsInstance(patient_resource, Patient)
+        self.assertEqual(patient_resource.id, "patient-example-02")
+
+        self.assertTrue(len(patient_resource.name) > 0)
+        self.assertEqual(patient_resource.name[0].family, "Schmidt")
+        self.assertEqual(patient_resource.name[0].given[0], "Hans")
+        self.assertEqual(str(patient_resource.birthDate), "1978-05-15")
+        self.assertEqual(patient_resource.gender, "male")
+
+    def test_fhir_bundle_german_lab_example_observations(self):
+        """Test the presence and content of observations in the German lab example bundle."""
+        bundle = fhir_bundle_german_lab_example()
+
+        observations = [e.resource for e in bundle.entry if e.resource and e.resource.get_resource_type() == "Observation"]
+        self.assertEqual(len(observations), 25) # 7 + 6 + 6 + 6 = 25 observations
+
+        # Define expected LOINC codes for each set
+        # Set 1: All 7 parameters
+        loincs_set1 = ["2324-2", "1558-6", "2093-3", "2085-9", "2089-1", "9830-1", "2571-8"]
+        # Set 2: Triglyceride ("2571-8") missing (6 parameters)
+        loincs_set2 = ["2324-2", "1558-6", "2093-3", "2085-9", "2089-1", "9830-1"]
+        # Set 3: LDL-Cholesterin ("2089-1") missing (6 parameters)
+        loincs_set3 = ["2324-2", "1558-6", "2093-3", "2085-9", "9830-1", "2571-8"]
+        # Set 4: Gamma-GT ("2324-2") missing (6 parameters)
+        loincs_set4 = ["1558-6", "2093-3", "2085-9", "2089-1", "9830-1", "2571-8"]
+
+        # Group observations by effectiveDateTime to distinguish sets
+        observations_by_date = {}
+        for obs in observations:
+            self.assertIsInstance(obs, Observation)
+            date_str = str(obs.effectiveDateTime.date()) # Use date part for grouping
+            if date_str not in observations_by_date:
+                observations_by_date[date_str] = []
+            observations_by_date[date_str].append(obs)
+
+        self.assertIn("2022-05-20", observations_by_date)
+        self.assertIn("2023-08-10", observations_by_date)
+        self.assertIn("2024-01-15", observations_by_date)
+        self.assertIn("2024-07-20", observations_by_date)
+
+        # Check observations for Set 1 ("2022-05-20")
+        obs_set1_list = observations_by_date["2022-05-20"]
+        self.assertEqual(len(obs_set1_list), len(loincs_set1))
+        present_loincs_s1 = [obs.code.coding[0].code for obs in obs_set1_list]
+        for loinc in loincs_set1:
+            self.assertIn(loinc, present_loincs_s1)
+
+        # Check observations for Set 2 ("2023-08-10")
+        obs_set2_list = observations_by_date["2023-08-10"]
+        self.assertEqual(len(obs_set2_list), len(loincs_set2))
+        present_loincs_s2 = [obs.code.coding[0].code for obs in obs_set2_list]
+        for loinc in loincs_set2:
+            self.assertIn(loinc, present_loincs_s2)
+        self.assertNotIn("2571-8", present_loincs_s2) # Triglyceride missing
+
+        # Check observations for Set 3 ("2024-01-15")
+        obs_set3_list = observations_by_date["2024-01-15"]
+        self.assertEqual(len(obs_set3_list), len(loincs_set3))
+        present_loincs_s3 = [obs.code.coding[0].code for obs in obs_set3_list]
+        for loinc in loincs_set3:
+            self.assertIn(loinc, present_loincs_s3)
+        self.assertNotIn("2089-1", present_loincs_s3) # LDL-Cholesterin missing
+
+        # Check observations for Set 4 ("2024-07-20")
+        obs_set4_list = observations_by_date["2024-07-20"]
+        self.assertEqual(len(obs_set4_list), len(loincs_set4))
+        present_loincs_s4 = [obs.code.coding[0].code for obs in obs_set4_list]
+        for loinc in loincs_set4:
+            self.assertIn(loinc, present_loincs_s4)
+        self.assertNotIn("2324-2", present_loincs_s4) # Gamma-GT missing
+
+        # Check some observation details (e.g. first observation for Schmidt from set 1)
+        schmidt_obs1 = next((obs for obs in obs_set1_list if obs.id == "obs-schmidt-01"), None)
+        self.assertIsNotNone(schmidt_obs1)
+        self.assertEqual(schmidt_obs1.code.coding[0].code, "2324-2") # Gamma-GT
+        self.assertEqual(schmidt_obs1.valueQuantity.value, 45.0)
+        self.assertEqual(schmidt_obs1.valueQuantity.unit, "U/L")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,117 @@
+import unittest
+import pandas as pd
+from src.fhir_research.utils import filter_fhir_dataframe
+
+class TestUtils(unittest.TestCase):
+
+    def setUp(self):
+        # Sample DataFrame mimicking structure from flatten_fhir_bundle
+        data = {
+            'id': ['obs1', 'obs2', 'obs3', 'obs4', 'obs5', 'obs6'],
+            'effectiveDateTime': pd.to_datetime([
+                '2023-01-01T10:00:00Z',
+                '2023-01-01T10:05:00Z',
+                '2023-01-02T11:00:00Z',
+                '2023-01-02T11:05:00Z',
+                '2023-01-03T12:00:00Z',
+                '2023-01-03T12:05:00Z'
+            ]),
+            'code_coding_0_code': ['CODE1', 'CODE2', 'CODE1', 'CODE3', 'CODE2', 'CODE4'],
+            'code_coding_0_display': ['Display1', 'Display2', 'Display1', 'Display3', 'Display2', 'Display4'],
+            'valueQuantity_value': [10.0, 20.0, 12.0, 30.0, 22.0, 40.0],
+            'valueQuantity_unit': ['mg/dL', 'mg/dL', 'mg/dL', 'U/L', 'mg/dL', 'U/L']
+        }
+        self.sample_df = pd.DataFrame(data)
+        # Ensure effectiveDateTime is timezone-aware, matching typical FHIR output
+        if not self.sample_df['effectiveDateTime'].dt.tz:
+             self.sample_df['effectiveDateTime'] = self.sample_df['effectiveDateTime'].dt.tz_localize('UTC')
+
+
+    def test_filter_fhir_dataframe_multiple_codes(self):
+        """Test filtering with a list of codes."""
+        filtered_df = filter_fhir_dataframe(
+            self.sample_df,
+            column_name="code_coding_0_code",
+            codes=["CODE1", "CODE3"]
+        )
+        self.assertEqual(len(filtered_df), 3)
+        self.assertTrue(all(filtered_df["code_coding_0_code"].isin(["CODE1", "CODE3"])))
+
+        # Test that date and value columns are correctly processed (simple check)
+        self.assertTrue(pd.api.types.is_datetime64_any_dtype(filtered_df['effectiveDateTime']))
+        self.assertTrue(pd.api.types.is_numeric_dtype(filtered_df['valueQuantity_value']))
+
+
+    def test_filter_fhir_dataframe_empty_codes_list(self):
+        """Test filtering with an empty list of codes."""
+        filtered_df = filter_fhir_dataframe(
+            self.sample_df,
+            column_name="code_coding_0_code",
+            codes=[]
+        )
+        self.assertTrue(filtered_df.equals(self.sample_df))
+        # Should be a copy
+        self.assertNotEqual(id(filtered_df), id(self.sample_df))
+
+    def test_filter_fhir_dataframe_none_codes(self):
+        """Test filtering with codes=None."""
+        filtered_df = filter_fhir_dataframe(
+            self.sample_df,
+            column_name="code_coding_0_code",
+            codes=None
+        )
+        self.assertTrue(filtered_df.equals(self.sample_df))
+        self.assertNotEqual(id(filtered_df), id(self.sample_df))
+
+    def test_filter_fhir_dataframe_empty_column_name(self):
+        """Test filtering with an empty column_name."""
+        filtered_df = filter_fhir_dataframe(
+            self.sample_df,
+            column_name="",
+            codes=["CODE1"]
+        )
+        self.assertTrue(filtered_df.equals(self.sample_df))
+        self.assertNotEqual(id(filtered_df), id(self.sample_df))
+
+    def test_filter_fhir_dataframe_non_existent_column(self):
+        """Test filtering with a non-existent column name."""
+        # According to current implementation, it prints a warning and returns a copy.
+        filtered_df = filter_fhir_dataframe(
+            self.sample_df,
+            column_name="non_existent_column",
+            codes=["CODE1"]
+        )
+        self.assertTrue(filtered_df.equals(self.sample_df))
+        self.assertNotEqual(id(filtered_df), id(self.sample_df))
+
+    def test_filter_fhir_dataframe_empty_input_df(self):
+        """Test filtering with an empty input DataFrame."""
+        empty_df = pd.DataFrame()
+        filtered_df = filter_fhir_dataframe(
+            empty_df,
+            column_name="code_coding_0_code",
+            codes=["CODE1"]
+        )
+        self.assertTrue(filtered_df.empty)
+
+    def test_filter_fhir_dataframe_input_df_none(self):
+        """Test filtering with None as input DataFrame."""
+        filtered_df = filter_fhir_dataframe(
+            None, # type: ignore
+            column_name="code_coding_0_code",
+            codes=["CODE1"]
+        )
+        self.assertTrue(filtered_df.empty)
+
+    def test_filter_no_matching_codes(self):
+        """Test filtering with codes that don't exist in the DataFrame."""
+        filtered_df = filter_fhir_dataframe(
+            self.sample_df,
+            column_name="code_coding_0_code",
+            codes=["NON_EXISTENT_CODE1", "NON_EXISTENT_CODE2"]
+        )
+        self.assertTrue(filtered_df.empty)
+        self.assertEqual(len(filtered_df), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit expands the `fhir_bundle_german_lab_example` to include a total of four sets of laboratory observations for the patient "Hans Schmidt". This provides a more comprehensive example.

Key changes:
- Added two new observation sets with different dates and varied lab values to `fhir_bundle_german_lab_example` in `src/fhir_research/examples.py`.
- Ensured that the new sets also demonstrate handling of missing values by omitting LDL-Cholesterin in the third set and Gamma-GT in the fourth set.
- Updated the corresponding unit tests in `tests/test_examples.py` to verify the presence of all four observation sets, the correct total count of observations, and the specific omissions in the new sets. All unit tests continue to pass.