### PR TITLE
I've updated the documentation for FHIR profiles in `docs/fhir-profil…

### DIFF
--- a/docs/fhir-profiles.md
+++ b/docs/fhir-profiles.md
@@ -5,5 +5,33 @@
     - `Patient.address` conforms to `http://fhir.de/StructureDefinition/address-de-basis`
 - **HDL Cholesterol Observation**: Uses the core FHIR Observation resource
     - Category: `laboratory`
-    - Code: LOINC `2085-9` ("Cholesterol in HDL [Mass/volume] in Serum or Plasma")
+    - Code: LOINC `2085-9` ("Cholesterol in HDL")
     - Units: `mg/dL` (UCUM code `mg/dL`)
+- **Blood Glucose Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `2339-0` ("Glucose [Mass/volume] in Blood by Test strip")
+    - Units: `mg/dL` (UCUM code `mg/dL`)
+- **Fasting Glucose Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `1558-6` ("Glucose^fasting")
+    - Units: `mg/dL` (UCUM code `mg/dL`)
+- **Total Cholesterol Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `2093-3` ("Cholesterol")
+    - Units: `mg/dL` (UCUM code `mg/dL`)
+- **LDL Cholesterol Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `2089-1` ("Cholesterol in LDL")
+    - Units: `mg/dL` (UCUM code `mg/dL`)
+- **Gamma Glutamyl Transferase Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `2324-2` ("Gamma glutamyl transferase")
+    - Units: `U/L` (UCUM code `U/L`)
+- **Triglyceride Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `2571-8` ("Triglyceride")
+    - Units: `mg/dL` (UCUM code `mg/dL`)
+- **Cholesterol Ratio Observation**: Uses the core FHIR Observation resource
+    - Category: `laboratory`
+    - Code: LOINC `9830-1` ("Cholesterol.total/Cholesterol in HDL")
+    - Units: `ratio` (UCUM code `{ratio}`)


### PR DESCRIPTION
…es.md` to include all observation types found in the example generation code (`src/fhir_research/examples.py`).

The following observation profiles are now documented:
- HDL Cholesterol (updated display name)
- Blood Glucose
- Fasting Glucose
- Total Cholesterol
- LDL Cholesterol
- Gamma Glutamyl Transferase
- Triglyceride
- Cholesterol Ratio

This ensures the documentation accurately reflects the data types used in your project examples.